### PR TITLE
Remove duplicate `NormalizedArgs` struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 image = { version = "0.24.7", features = ["gif", "jpeg", "png"] }
-clap = { version = "4.4.6", features = ["derive"] }
+clap = { version = "4.4.6", features = ["derive", "string"] }
 directories = "5.0.1"
 path-clean = "1.0.1"
 thiserror = "1.0.50"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,8 +37,8 @@ pub struct Args {
     /// Specifies the output directory for the thumbnail.
     ///
     /// If unspecified, it defaults to the user's platform-specific 'Pictures' folder
-    #[arg(short = 'd', long = "outDir")]
-    pub out_dir: Option<PathBuf>,
+    #[arg(short = 'd', long = "outDir", default_value = default_output_dir().into_os_string())]
+    pub out_dir: PathBuf,
 
     /// The thumbnail's output format.
     #[arg(short, long, default_value_t = ImageFormat::Png)]
@@ -92,7 +92,7 @@ impl Args {
         NormalizedArgs {
             path,
             out_name,
-            out_dir,
+            out_dir: self.out_dir,
             format: self.format,
             sampling_filter: self.sampling_filter,
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,8 +21,6 @@ use path_clean::PathClean;
 
 use crate::{sampling::SamplingFilter, ImageFormat};
 
-const DEFAULT_OUTPUT_FORMAT: ImageFormat = ImageFormat::Png;
-
 const DEFAULT_SAMPLING_FILTER: SamplingFilter = SamplingFilter::Lanczos3;
 
 /// CLI arguments parsed by *clap* to configure the thumbnail generation process.
@@ -45,8 +43,8 @@ pub struct Args {
     pub out_dir: Option<PathBuf>,
 
     /// The thumbnail's output format.
-    #[arg(short, long)]
-    pub format: Option<ImageFormat>,
+    #[arg(short, long, default_value_t = ImageFormat::Png)]
+    pub format: ImageFormat,
 
     /// Sampling algorithm to use for thumbnail generation.
     #[arg(short = 's', long = "sampling")]
@@ -77,7 +75,6 @@ impl Args {
     /// Returns parsed arguments with reasonable defaults.
     pub fn normalize(self) -> NormalizedArgs {
         let out_dir = self.out_dir.unwrap_or(default_output_dir());
-        let format = self.format.unwrap_or(DEFAULT_OUTPUT_FORMAT);
         let sampling_filter = self.sampling_filter.unwrap_or(DEFAULT_SAMPLING_FILTER);
         let out_name = self.out_name.unwrap_or_else(|| {
             let p_without_ext = self.path.with_extension("");
@@ -87,7 +84,11 @@ impl Args {
                 panic!("Invalid empty path to image file")
             }
 
-            format!("{}_thumb.{}", &original_filename.to_str().unwrap(), &format)
+            format!(
+                "{}_thumb.{}",
+                &original_filename.to_str().unwrap(),
+                &self.format
+            )
         });
 
         let path = abs_path_to_img(&self.path).unwrap();
@@ -96,7 +97,7 @@ impl Args {
             path,
             out_name,
             out_dir,
-            format,
+            format: self.format,
             sampling_filter,
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use std::path::{Path, PathBuf};
-use std::{env::current_dir, error::Error};
 
 use clap::Parser;
 use directories::UserDirs;
-use path_clean::PathClean;
 
 use crate::{sampling::SamplingFilter, ImageFormat};
 
@@ -49,59 +47,30 @@ pub struct Args {
     pub sampling_filter: SamplingFilter,
 }
 
-/// Represents CLI arguments parsed by `clap` with reasonable
-/// defaults for arguments whose parsed values are *None*.
-#[derive(Debug)]
-pub struct NormalizedArgs {
-    /// Local image file path for generating the thumbnail
-    pub path: Box<Path>,
-
-    /// Generated thumbnail name.
-    pub out_name: String,
-
-    /// Specifies the output directory for the thumbnail.
-    pub out_dir: PathBuf,
-
-    /// The thumbnail's output format.
-    pub format: ImageFormat,
-
-    /// Sampling algorithm to use for thumbnail generation.
-    pub sampling_filter: SamplingFilter,
-}
-
 impl Args {
-    /// Returns parsed arguments with reasonable defaults.
-    pub fn normalize(self) -> NormalizedArgs {
-        let out_name = self.out_name.unwrap_or_else(|| {
-            let p_without_ext = self.path.with_extension("");
-            let original_filename = p_without_ext.file_name().unwrap();
-
-            if original_filename.is_empty() {
-                panic!("Invalid empty path to image file")
-            }
-
-            format!(
-                "{}_thumb.{}",
-                &original_filename.to_str().unwrap(),
-                &self.format
-            )
-        });
-
-        let path = abs_path_to_img(&self.path).unwrap();
-
-        NormalizedArgs {
-            path,
-            out_name,
-            out_dir: self.out_dir,
-            format: self.format,
-            sampling_filter: self.sampling_filter,
-        }
-    }
-}
-
-impl NormalizedArgs {
     pub fn get_final_output_path(&self) -> PathBuf {
-        self.out_dir.join(&self.out_name)
+        self.out_dir.join(self.get_out_name())
+    }
+
+    fn get_out_name(&self) -> String {
+        self.out_name
+            .as_ref()
+            .map(|val| val.to_string())
+            .unwrap_or_else(|| {
+                let p_without_ext = self.path.with_extension("");
+                let original_filename = p_without_ext.file_name().unwrap();
+
+                if original_filename.is_empty() {
+                    panic!("Invalid empty path to image file")
+                }
+
+                format!(
+                    "{}_thumb.{}",
+                    &original_filename.to_str().unwrap(),
+                    &self.format
+                )
+                .to_string()
+            })
     }
 }
 
@@ -115,17 +84,4 @@ fn default_output_dir() -> PathBuf {
             panic!("Unable to find user 'Pictures' directory in the operating sytem")
         })
         .to_path_buf()
-}
-
-fn abs_path_to_img(path: &impl AsRef<Path>) -> Result<Box<Path>, Box<dyn Error>> {
-    let path = path.as_ref();
-
-    let absolute_path = if path.is_absolute() {
-        path.to_path_buf().into_boxed_path()
-    } else {
-        current_dir()?.join(path).into_boxed_path()
-    }
-    .clean();
-
-    Ok(absolute_path.into_boxed_path())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,8 +21,6 @@ use path_clean::PathClean;
 
 use crate::{sampling::SamplingFilter, ImageFormat};
 
-const DEFAULT_SAMPLING_FILTER: SamplingFilter = SamplingFilter::Lanczos3;
-
 /// CLI arguments parsed by *clap* to configure the thumbnail generation process.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -47,8 +45,8 @@ pub struct Args {
     pub format: ImageFormat,
 
     /// Sampling algorithm to use for thumbnail generation.
-    #[arg(short = 's', long = "sampling")]
-    pub sampling_filter: Option<SamplingFilter>,
+    #[arg(short = 's', long = "sampling", default_value_t = SamplingFilter::Lanczos3)]
+    pub sampling_filter: SamplingFilter,
 }
 
 /// Represents CLI arguments parsed by `clap` with reasonable
@@ -74,8 +72,6 @@ pub struct NormalizedArgs {
 impl Args {
     /// Returns parsed arguments with reasonable defaults.
     pub fn normalize(self) -> NormalizedArgs {
-        let out_dir = self.out_dir.unwrap_or(default_output_dir());
-        let sampling_filter = self.sampling_filter.unwrap_or(DEFAULT_SAMPLING_FILTER);
         let out_name = self.out_name.unwrap_or_else(|| {
             let p_without_ext = self.path.with_extension("");
             let original_filename = p_without_ext.file_name().unwrap();
@@ -98,7 +94,7 @@ impl Args {
             out_name,
             out_dir,
             format: self.format,
-            sampling_filter,
+            sampling_filter: self.sampling_filter,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,8 @@ use ytthumb::{cli::Args, run};
 
 fn main() {
     let args = Args::parse();
-    let normalized_args = &args.normalize();
 
-    let img_result = run(normalized_args);
+    let img_result = run(&args);
 
     match img_result {
         Ok(_) => println!("Successfully generated thumbnail"),

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -1,5 +1,6 @@
 use clap::ValueEnum;
 use image::imageops::FilterType;
+use strum_macros::{Display, EnumString, EnumVariantNames};
 
 /// Sampling algorithm to use for thumbnail generation.
 ///
@@ -7,7 +8,8 @@ use image::imageops::FilterType;
 /// This is equivalent to the `FilterType` provided by the *image* crate.
 ///
 /// We duplicate this enum to make it compatible with *clap*s `ValueEnum`.
-#[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]
+#[derive(ValueEnum, Display, EnumString, EnumVariantNames, Clone, Copy, Debug, PartialEq)]
+#[strum(serialize_all = "lowercase")]
 pub enum SamplingFilter {
     /// Nearest Neighbor
     Nearest,


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->
This commit provides reasonable defaults in the `Args` struct directly.
Previously, we used a `NormalizedArgs` struct from which we accessed
normalized arguments and where we transformed the parsed cli arguments
to non-optional fields.
This isn't needed since we can simply provide defaults in the `Args`
struct directly.

Additionally, functions that used to live in `NormalizedArgs` struct
are now implemeneted in the `Args` struct.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
